### PR TITLE
(For Jacob) Added support for json schemas in yaml

### DIFF
--- a/jsonschema2pojo-core/pom.xml
+++ b/jsonschema2pojo-core/pom.xml
@@ -18,6 +18,10 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.javaparser</groupId>
             <artifactId>javaparser</artifactId>
         </dependency>

--- a/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
+++ b/jsonschema2pojo-core/src/test/java/org/jsonschema2pojo/ContentResolverTest.java
@@ -90,6 +90,21 @@ public class ContentResolverTest {
 
     }
 
+    @Test
+    public void yamlURIsAreResolved() throws IOException {
+        URI schemaFile;
+        JsonNode uriContent;
+
+        schemaFile = URI.create("classpath:schema/address.yaml");
+        uriContent = resolver.resolve(schemaFile);
+        assertThat(uriContent.path("description").asText().length(), is(greaterThan(0)));
+
+        schemaFile = URI.create("java:schema/address.yaml");
+        uriContent = resolver.resolve(schemaFile);
+        assertThat(uriContent.path("description").asText().length(), is(greaterThan(0)));
+
+    }
+
     private URI createSchemaFile() throws IOException {
         File tempFile = File.createTempFile("jsonschema2pojotest", "json");
         tempFile.deleteOnExit();
@@ -106,5 +121,4 @@ public class ContentResolverTest {
         
         return tempFile.toURI();
     }
-    
 }

--- a/jsonschema2pojo-core/src/test/resources/schema/address.yaml
+++ b/jsonschema2pojo-core/src/test/resources/schema/address.yaml
@@ -1,0 +1,27 @@
+---
+description: An Address following the convention of http://microformats.org/wiki/hcard
+type: object
+properties:
+  post-office-box:
+    type: string
+  extended-address:
+    type: string
+  street-address:
+    type: string
+  locality:
+    type: string
+    required: true
+  region:
+    type: string
+    required: true
+  postal-code:
+    type: string
+  country-name:
+    type: string
+    required: true
+dependencies:
+  post-office-box: street-address
+  extended-address: street-address
+  street-address: region
+  locality: region
+  region: country-name

--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,11 @@
                 <version>2.2.0</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
+                <version>2.2.0</version>
+            </dependency>
+            <dependency>
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>


### PR DESCRIPTION
@jburnim 

Adds support for YAML-formatted JSON schemas. YAML is a much more human-friendly format, including support for comments, multi-line strings and more forgiving syntax. This is especially important as we increase the amount of documentation that's included in JSON schemas.